### PR TITLE
fix: añadir verificación de reservas activas antes de eliminar huéspedes y habitaciones

### DIFF
--- a/03-ReservasHotel/app/endpoints/reservations.py
+++ b/03-ReservasHotel/app/endpoints/reservations.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from datetime import date
 from app.database import get_db
@@ -126,4 +127,6 @@ def delete_reservation(reservation_id: int, db: Session = Depends(get_db)):
 
     db.delete(reservation)
     db.commit()
-    return None
+    return JSONResponse(content={
+        "detail": "Reserva eliminada correctamente"
+    })


### PR DESCRIPTION
Se agregaron validaciones en los endpoints DELETE de huespedes y habitaciones para verificar que no hayan reservas activas relacionadas.